### PR TITLE
feat(eth): adds handlers for new electra attestations

### DIFF
--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -393,7 +393,10 @@ func desiredPubSubBaseTopics() []string {
 		p2p.GossipBlockMessage,
 		p2p.GossipAggregateAndProofMessage,
 		p2p.GossipAttestationMessage,
-		p2p.GossipExitMessage,
+		// In relation to https://github.com/probe-lab/hermes/issues/24
+		// we unfortunatelly can't validate the messages (yet)
+		// thus, better not to forward invalid messages
+		// p2p.GossipExitMessage,
 		p2p.GossipAttesterSlashingMessage,
 		p2p.GossipProposerSlashingMessage,
 		p2p.GossipContributionAndProofMessage,
@@ -443,10 +446,10 @@ func topicFormatFromBase(topicBase string) (string, error) {
 func hasSubnets(topic string) (subnets uint64, hasSubnets bool) {
 	switch topic {
 	case p2p.GossipAttestationMessage:
-		return uint64(2), true
+		return globalBeaconConfig.AttestationSubnetCount, true
 
 	case p2p.GossipSyncCommitteeMessage:
-		return uint64(2), true
+		return globalBeaconConfig.SyncCommitteeSubnetCount, true
 
 	case p2p.GossipBlobSidecarMessage:
 		return globalBeaconConfig.BlobsidecarSubnetCount, true

--- a/eth/output_full.go
+++ b/eth/output_full.go
@@ -50,6 +50,11 @@ type TraceEventAttestationElectra struct {
 	AttestationElectra *ethtypes.AttestationElectra
 }
 
+type TraceEventSingleAttestation struct {
+	host.TraceEventPayloadMetaData
+	SingleAttestation *ethtypes.SingleAttestation
+}
+
 type TraceEventSignedAggregateAttestationAndProof struct {
 	host.TraceEventPayloadMetaData
 	SignedAggregateAttestationAndProof *ethtypes.SignedAggregateAttestationAndProof
@@ -139,6 +144,8 @@ func (t *FullOutput) RenderPayload(evt *host.TraceEvent, msg *pubsub.Message, ds
 		payload, err = t.renderAttestation(msg, d)
 	case *ethtypes.AttestationElectra:
 		payload, err = t.renderAttestationElectra(msg, d)
+	case *ethtypes.SingleAttestation:
+		payload, err = t.renderSingleAttestation(msg, d)
 	case *ethtypes.SignedAggregateAttestationAndProof:
 		payload, err = t.renderAggregateAttestationAndProof(msg, d)
 	case *ethtypes.SignedAggregateAttestationAndProofElectra:
@@ -295,6 +302,22 @@ func (t *FullOutput) renderAttestationElectra(
 			MsgSize: len(msg.Data),
 		},
 		AttestationElectra: attestation,
+	}, nil
+}
+
+func (t *FullOutput) renderSingleAttestation(
+	msg *pubsub.Message,
+	attestation *ethtypes.SingleAttestation,
+) (*TraceEventSingleAttestation, error) {
+	return &TraceEventSingleAttestation{
+		TraceEventPayloadMetaData: host.TraceEventPayloadMetaData{
+			PeerID:  msg.ReceivedFrom.String(),
+			Topic:   msg.GetTopic(),
+			Seq:     msg.GetSeqno(),
+			MsgID:   hex.EncodeToString([]byte(msg.ID)),
+			MsgSize: len(msg.Data),
+		},
+		SingleAttestation: attestation,
 	}, nil
 }
 

--- a/eth/output_full.go
+++ b/eth/output_full.go
@@ -45,9 +45,19 @@ type TraceEventAttestation struct {
 	Attestation *ethtypes.Attestation
 }
 
+type TraceEventAttestationElectra struct {
+	host.TraceEventPayloadMetaData
+	AttestationElectra *ethtypes.AttestationElectra
+}
+
 type TraceEventSignedAggregateAttestationAndProof struct {
 	host.TraceEventPayloadMetaData
 	SignedAggregateAttestationAndProof *ethtypes.SignedAggregateAttestationAndProof
+}
+
+type TraceEventSignedAggregateAttestationAndProofElectra struct {
+	host.TraceEventPayloadMetaData
+	SignedAggregateAttestationAndProofElectra *ethtypes.SignedAggregateAttestationAndProofElectra
 }
 
 type TraceEventSignedContributionAndProof struct {
@@ -127,8 +137,12 @@ func (t *FullOutput) RenderPayload(evt *host.TraceEvent, msg *pubsub.Message, ds
 		payload, err = t.renderElectraBlock(msg, d)
 	case *ethtypes.Attestation:
 		payload, err = t.renderAttestation(msg, d)
+	case *ethtypes.AttestationElectra:
+		payload, err = t.renderAttestationElectra(msg, d)
 	case *ethtypes.SignedAggregateAttestationAndProof:
 		payload, err = t.renderAggregateAttestationAndProof(msg, d)
+	case *ethtypes.SignedAggregateAttestationAndProofElectra:
+		payload, err = t.renderAggregateAttestationAndProofElectra(msg, d)
 	case *ethtypes.SignedContributionAndProof:
 		payload, err = t.renderContributionAndProof(msg, d)
 	case *ethtypes.VoluntaryExit:
@@ -248,6 +262,7 @@ func (t *FullOutput) renderElectraBlock(
 			MsgID:   hex.EncodeToString([]byte(msg.ID)),
 			MsgSize: len(msg.Data),
 		},
+		Block: block,
 	}, nil
 }
 
@@ -267,6 +282,22 @@ func (t *FullOutput) renderAttestation(
 	}, nil
 }
 
+func (t *FullOutput) renderAttestationElectra(
+	msg *pubsub.Message,
+	attestation *ethtypes.AttestationElectra,
+) (*TraceEventAttestationElectra, error) {
+	return &TraceEventAttestationElectra{
+		TraceEventPayloadMetaData: host.TraceEventPayloadMetaData{
+			PeerID:  msg.ReceivedFrom.String(),
+			Topic:   msg.GetTopic(),
+			Seq:     msg.GetSeqno(),
+			MsgID:   hex.EncodeToString([]byte(msg.ID)),
+			MsgSize: len(msg.Data),
+		},
+		AttestationElectra: attestation,
+	}, nil
+}
+
 func (t *FullOutput) renderAggregateAttestationAndProof(
 	msg *pubsub.Message,
 	agg *ethtypes.SignedAggregateAttestationAndProof,
@@ -280,6 +311,22 @@ func (t *FullOutput) renderAggregateAttestationAndProof(
 			MsgSize: len(msg.Data),
 		},
 		SignedAggregateAttestationAndProof: agg,
+	}, nil
+}
+
+func (t *FullOutput) renderAggregateAttestationAndProofElectra(
+	msg *pubsub.Message,
+	agg *ethtypes.SignedAggregateAttestationAndProofElectra,
+) (*TraceEventSignedAggregateAttestationAndProofElectra, error) {
+	return &TraceEventSignedAggregateAttestationAndProofElectra{
+		TraceEventPayloadMetaData: host.TraceEventPayloadMetaData{
+			PeerID:  msg.ReceivedFrom.String(),
+			Topic:   msg.GetTopic(),
+			Seq:     msg.GetSeqno(),
+			MsgID:   hex.EncodeToString([]byte(msg.ID)),
+			MsgSize: len(msg.Data),
+		},
+		SignedAggregateAttestationAndProofElectra: agg,
 	}, nil
 }
 

--- a/eth/output_full_test.go
+++ b/eth/output_full_test.go
@@ -261,6 +261,12 @@ func TestFullOutputRenderMethods(t *testing.T) {
 				require.Equal(t, hex.EncodeToString(baseMsg.GetSeqno()), hex.EncodeToString(typedResult.Seq))
 				require.Equal(t, len(baseMsg.GetData()), typedResult.MsgSize)
 				require.Equal(t, tc.payload.(*ethtypes.AttestationElectra), typedResult.AttestationElectra)
+			case *TraceEventSingleAttestation:
+				require.Equal(t, baseMsg.ReceivedFrom.String(), typedResult.PeerID)
+				require.Equal(t, baseMsg.GetTopic(), typedResult.Topic)
+				require.Equal(t, hex.EncodeToString(baseMsg.GetSeqno()), hex.EncodeToString(typedResult.Seq))
+				require.Equal(t, len(baseMsg.GetData()), typedResult.MsgSize)
+				require.Equal(t, tc.payload.(*ethtypes.SingleAttestation), typedResult.SingleAttestation)
 			case *TraceEventSignedAggregateAttestationAndProofElectra:
 				require.Equal(t, baseMsg.ReceivedFrom.String(), typedResult.PeerID)
 				require.Equal(t, baseMsg.GetTopic(), typedResult.Topic)

--- a/eth/output_full_test.go
+++ b/eth/output_full_test.go
@@ -82,11 +82,27 @@ func TestFullOutputRenderMethods(t *testing.T) {
 			},
 		},
 		{
+			name:         "renderAttestationElectra",
+			payload:      &ethtypes.AttestationElectra{},
+			expectedType: &TraceEventAttestationElectra{},
+			render: func(msg *pubsub.Message, payload any) (any, error) {
+				return renderer.renderAttestationElectra(msg, payload.(*ethtypes.AttestationElectra))
+			},
+		},
+		{
 			name:         "renderAggregateAttestationAndProof",
 			payload:      &ethtypes.SignedAggregateAttestationAndProof{},
 			expectedType: &TraceEventSignedAggregateAttestationAndProof{},
 			render: func(msg *pubsub.Message, payload any) (any, error) {
 				return renderer.renderAggregateAttestationAndProof(msg, payload.(*ethtypes.SignedAggregateAttestationAndProof))
+			},
+		},
+		{
+			name:         "renderAggregateAttestationAndProofElectra",
+			payload:      &ethtypes.SignedAggregateAttestationAndProofElectra{},
+			expectedType: &TraceEventSignedAggregateAttestationAndProofElectra{},
+			render: func(msg *pubsub.Message, payload any) (any, error) {
+				return renderer.renderAggregateAttestationAndProofElectra(msg, payload.(*ethtypes.SignedAggregateAttestationAndProofElectra))
 			},
 		},
 		{
@@ -239,6 +255,18 @@ func TestFullOutputRenderMethods(t *testing.T) {
 				require.Equal(t, hex.EncodeToString(baseMsg.GetSeqno()), hex.EncodeToString(typedResult.Seq))
 				require.Equal(t, len(baseMsg.GetData()), typedResult.MsgSize)
 				require.Equal(t, tc.payload.(*ethtypes.AttesterSlashing), typedResult.AttesterSlashing)
+			case *TraceEventAttestationElectra:
+				require.Equal(t, baseMsg.ReceivedFrom.String(), typedResult.PeerID)
+				require.Equal(t, baseMsg.GetTopic(), typedResult.Topic)
+				require.Equal(t, hex.EncodeToString(baseMsg.GetSeqno()), hex.EncodeToString(typedResult.Seq))
+				require.Equal(t, len(baseMsg.GetData()), typedResult.MsgSize)
+				require.Equal(t, tc.payload.(*ethtypes.AttestationElectra), typedResult.AttestationElectra)
+			case *TraceEventSignedAggregateAttestationAndProofElectra:
+				require.Equal(t, baseMsg.ReceivedFrom.String(), typedResult.PeerID)
+				require.Equal(t, baseMsg.GetTopic(), typedResult.Topic)
+				require.Equal(t, hex.EncodeToString(baseMsg.GetSeqno()), hex.EncodeToString(typedResult.Seq))
+				require.Equal(t, len(baseMsg.GetData()), typedResult.MsgSize)
+				require.Equal(t, tc.payload.(*ethtypes.SignedAggregateAttestationAndProofElectra), typedResult.SignedAggregateAttestationAndProofElectra)
 			default:
 				t.Fatalf("unexpected result type: %T", result)
 			}

--- a/eth/output_kinesis.go
+++ b/eth/output_kinesis.go
@@ -50,6 +50,8 @@ func (k *KinesisOutput) RenderPayload(evt *host.TraceEvent, msg *pubsub.Message,
 		payload, err = k.renderCapellaBlock(msg, d)
 	case *ethtypes.SignedBeaconBlockDeneb:
 		payload, err = k.renderDenebBlock(msg, d)
+	case *ethtypes.SignedBeaconBlockElectra:
+		payload, err = k.renderElectraBlock(msg, d)
 	case *ethtypes.Attestation:
 		payload, err = k.renderAttestation(msg, d)
 	case *ethtypes.AttestationElectra:

--- a/eth/output_kinesis.go
+++ b/eth/output_kinesis.go
@@ -54,6 +54,8 @@ func (k *KinesisOutput) RenderPayload(evt *host.TraceEvent, msg *pubsub.Message,
 		payload, err = k.renderAttestation(msg, d)
 	case *ethtypes.AttestationElectra:
 		payload, err = k.renderAttestationElectra(msg, d)
+	case *ethtypes.SingleAttestation:
+		payload, err = k.renderSingleAttestation(msg, d)
 	case *ethtypes.SignedAggregateAttestationAndProof:
 		payload, err = k.renderAggregateAttestationAndProof(msg, d)
 	case *ethtypes.SignedAggregateAttestationAndProofElectra:
@@ -271,6 +273,26 @@ func (k *KinesisOutput) renderAttestationElectra(
 	}
 
 	return payload, nil
+}
+
+func (k *KinesisOutput) renderSingleAttestation(
+	msg *pubsub.Message,
+	attestation *ethtypes.SingleAttestation,
+) (map[string]any, error) {
+	return map[string]any{
+		"PeerID":          msg.ReceivedFrom,
+		"Topic":           msg.GetTopic(),
+		"Seq":             hex.EncodeToString(msg.GetSeqno()),
+		"MsgID":           hex.EncodeToString([]byte(msg.ID)),
+		"MsgSize":         len(msg.Data),
+		"CommIdx":         attestation.GetData().GetCommitteeIndex(),
+		"Slot":            attestation.GetData().GetSlot(),
+		"BeaconBlockRoot": attestation.GetData().GetBeaconBlockRoot(),
+		"Source":          attestation.GetData().GetSource(),
+		"Target":          attestation.GetData().GetTarget(),
+		"CommitteeId":     attestation.GetCommitteeId(),
+		"AttesterIndex":   attestation.GetAttesterIndex(),
+	}, nil
 }
 
 func (k *KinesisOutput) renderAggregateAttestationAndProof(

--- a/eth/output_kinesis_test.go
+++ b/eth/output_kinesis_test.go
@@ -393,6 +393,14 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetData().GetBeaconBlockRoot(), result["BeaconBlockRoot"])
 				require.Equal(t, typedResult.GetData().GetSource(), result["Source"])
 				require.Equal(t, typedResult.GetData().GetTarget(), result["Target"])
+			case *ethtypes.SingleAttestation:
+				require.Equal(t, typedResult.GetData().GetSlot(), result["Slot"])
+				require.Equal(t, typedResult.GetData().GetCommitteeIndex(), result["CommIdx"])
+				require.Equal(t, typedResult.GetData().GetBeaconBlockRoot(), result["BeaconBlockRoot"])
+				require.Equal(t, typedResult.GetData().GetSource(), result["Source"])
+				require.Equal(t, typedResult.GetData().GetTarget(), result["Target"])
+				require.Equal(t, typedResult.GetCommitteeId(), result["CommitteeId"])
+				require.Equal(t, typedResult.GetAttesterIndex(), result["AttesterIndex"])
 			case *ethtypes.SignedAggregateAttestationAndProofElectra:
 				require.Equal(t, typedResult.GetMessage().GetAggregatorIndex(), result["AggIdx"])
 				require.Equal(t, hexutil.Encode(typedResult.GetMessage().GetSelectionProof()), result["SelectionProof"])

--- a/eth/output_kinesis_test.go
+++ b/eth/output_kinesis_test.go
@@ -342,6 +342,16 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
 				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+			case *ethtypes.SignedBeaconBlockElectra:
+				root, err := typedResult.GetBlock().HashTreeRoot()
+				if err != nil {
+					t.Fatalf("failed to determine block hash tree root: %v", err)
+				}
+
+				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
+				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
+				require.Equal(t, root, result["Root"])
+				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.Attestation:
 				require.Equal(t, typedResult.GetData().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetData().GetCommitteeIndex(), result["CommIdx"])

--- a/eth/output_kinesis_test.go
+++ b/eth/output_kinesis_test.go
@@ -114,6 +114,24 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 			},
 		},
 		{
+			name: "renderAttestationElectra",
+			payload: &ethtypes.AttestationElectra{
+				Data: &ethtypes.AttestationData{
+					Slot:            1,
+					CommitteeIndex:  2,
+					BeaconBlockRoot: genMockBytes(32),
+					Source:          &ethtypes.Checkpoint{},
+					Target:          &ethtypes.Checkpoint{},
+				},
+				CommitteeBits:   genMockBytes(8),
+				AggregationBits: genMockBytes(131072),
+			},
+			expected: commonExpected,
+			render: func(msg *pubsub.Message, payload any) (map[string]any, error) {
+				return renderer.renderAttestationElectra(msg, payload.(*ethtypes.AttestationElectra))
+			},
+		},
+		{
 			name: "renderAggregateAttestationAndProof",
 			payload: &ethtypes.SignedAggregateAttestationAndProof{
 				Signature: genMockBytes(96),
@@ -125,6 +143,29 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 			expected: commonExpected,
 			render: func(msg *pubsub.Message, payload any) (map[string]any, error) {
 				return renderer.renderAggregateAttestationAndProof(msg, payload.(*ethtypes.SignedAggregateAttestationAndProof))
+			},
+		},
+		{
+			name: "renderAggregateAttestationAndProofElectra",
+			payload: &ethtypes.SignedAggregateAttestationAndProofElectra{
+				Signature: genMockBytes(96),
+				Message: &ethtypes.AggregateAttestationAndProofElectra{
+					AggregatorIndex: 1,
+					SelectionProof:  genMockBytes(96),
+					Aggregate: &ethtypes.AttestationElectra{
+						Data: &ethtypes.AttestationData{
+							Slot:            1,
+							CommitteeIndex:  2,
+							BeaconBlockRoot: genMockBytes(32),
+						},
+						CommitteeBits:   genMockBytes(8),
+						AggregationBits: genMockBytes(131072),
+					},
+				},
+			},
+			expected: commonExpected,
+			render: func(msg *pubsub.Message, payload any) (map[string]any, error) {
+				return renderer.renderAggregateAttestationAndProofElectra(msg, payload.(*ethtypes.SignedAggregateAttestationAndProofElectra))
 			},
 		},
 		{
@@ -346,6 +387,16 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 			case *ethtypes.AttesterSlashing:
 				require.Equal(t, typedResult.GetAttestation_1().GetAttestingIndices(), result["Att1_indices"])
 				require.Equal(t, typedResult.GetAttestation_2().GetAttestingIndices(), result["Att2_indices"])
+			case *ethtypes.AttestationElectra:
+				require.Equal(t, typedResult.GetData().GetSlot(), result["Slot"])
+				require.Equal(t, typedResult.GetData().GetCommitteeIndex(), result["CommIdx"])
+				require.Equal(t, typedResult.GetData().GetBeaconBlockRoot(), result["BeaconBlockRoot"])
+				require.Equal(t, typedResult.GetData().GetSource(), result["Source"])
+				require.Equal(t, typedResult.GetData().GetTarget(), result["Target"])
+			case *ethtypes.SignedAggregateAttestationAndProofElectra:
+				require.Equal(t, typedResult.GetMessage().GetAggregatorIndex(), result["AggIdx"])
+				require.Equal(t, hexutil.Encode(typedResult.GetMessage().GetSelectionProof()), result["SelectionProof"])
+				require.Equal(t, hexutil.Encode(typedResult.GetSignature()), result["Sig"])
 			default:
 				t.Fatalf("unexpected result type: %T", result)
 			}

--- a/eth/pubsub.go
+++ b/eth/pubsub.go
@@ -221,7 +221,13 @@ func (p *PubSub) handleAttestation(ctx context.Context, msg *pubsub.Message) err
 		}
 	)
 
-	evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.Attestation{})
+	switch p.cfg.ForkVersion {
+	case ElectraForkVersion:
+		evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.SingleAttestation{})
+	default:
+		evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.Attestation{})
+	}
+
 	if err != nil {
 		slog.Warn(
 			"failed rendering topic handler event", "topic", msg.GetTopic(), "err", tele.LogAttrError(err),
@@ -254,7 +260,13 @@ func (p *PubSub) handleAggregateAndProof(ctx context.Context, msg *pubsub.Messag
 		}
 	)
 
-	evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.SignedAggregateAttestationAndProof{})
+	switch p.cfg.ForkVersion {
+	case ElectraForkVersion:
+		evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.SignedAggregateAttestationAndProofElectra{})
+	default:
+		evt, err = p.dsr.RenderPayload(evt, msg, &ethtypes.SignedAggregateAttestationAndProof{})
+	}
+
 	if err != nil {
 		slog.Warn(
 			"failed rendering topic handler event", "topic", msg.GetTopic(), "err", tele.LogAttrError(err),

--- a/host/host.go
+++ b/host/host.go
@@ -129,7 +129,7 @@ func (h *Host) InitGossipSub(ctx context.Context, opts ...pubsub.Option) (*pubsu
 		pubsub.WithRawTracer(h),
 		pubsub.WithRawTracer(mt),
 		pubsub.WithEventTracer(h),
-		// pubsub.WithPeerScoreInspect(h.UpdatePeerScore, h.sk.freq),
+		pubsub.WithPeerScoreInspect(h.UpdatePeerScore, h.sk.freq),
 	)
 	ps, err := pubsub.NewGossipSub(ctx, h, opts...)
 	if err != nil {


### PR DESCRIPTION
- new `SingleAttestation` msgs seem to be coming through on the existing `p2p.GossipAttestationMessage (beacon_attestation)` topic.
- likewise, new `SignedAggregateAttestationAndProofElectra` on the existing `p2p.GossipAggregateAndProofMessage (beacon_aggregate_and_proof)` topic

This PR, extends #9...

- And handles parsing the appropriate messages based on configured fork version.
- Ensures signed electra `block` is passed as part of output full message (was missing).
- Ensures signed electra blocks are parsed by output kinesis.

**Resolves:**

```bash
warn  | 10:22:09.569101 | failed rendering topic handler event      topic=/eth2/019e21ad/beacon_attestation_0/ssz_snappy err="err=decode gossip message: invalid ssz encoding. first variable element offset indexes into fixed value data"
warn  | 10:22:09.571595 | failed rendering topic handler event      topic=/eth2/019e21ad/beacon_aggregate_and_proof/ssz_snappy err="err=decode gossip message: invalid ssz encoding. first variable element offset indexes into fixed value data"
```

**Holesky Testing:**

1. Port forward to a prysm node, eg: `utility|holesky`
    - `kubectl port-forward pod/holesky-prysm-reth-001-beacon-0 5052:5052 4000:4000 31912:31912`)
2. Run Hermes
    - ```go run ./cmd/hermes eth --chain=holesky --prysm.host=127.0.0.1 --prysm.port.http=5052 --prysm.port.grpc=4000 --devp2p.host=0.0.0.0 --devp2p.port=31912 --libp2p.host=0.0.0.0 --libp2p.port=31912```
    - Observe no decoding errors

> BN must be sync'd otherwise no dice.

**Local Testing:**
1. Use kurtosis cfg:
```
participants:
  - el_type: nethermind
    el_image: ethpandaops/nethermind:master
    cl_type: prysm
    cl_image: ethpandaops/prysm-beacon-chain:develop
  - el_type: geth
    el_image: ethpandaops/geth:prague-devnet-6
    cl_type: prysm
    cl_image: ethpandaops/prysm-beacon-chain:develop
network_params:
  electra_fork_epoch: 1
```
2. Run Hermes:
```
go run ./cmd/hermes --data.stream.type=callback eth --chain=devnet --devp2p.host=0.0.0.0 --libp2p.host=0.0.0.0 --prysm.host=127.0.0.1 --prysm.port.http=33001 --prysm.port.grpc=33003 --genesis.ssz.url=http://127.0.0.1:40000/network-configs/genesis.ssz --config.yaml.url=http://127.0.0.1:40000/network-configs/config.yaml --bootnodes.yaml.url=http://127.0.0.1:40000/network-configs/boot_enr.yaml --deposit-contract-block.txt.url=http://127.0.0.1:40000/network-configs/deposit_contract_block.txt
```
