### PR TITLE
feat: add configurable subnets for gossip topics

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,7 +1,0 @@
-{
-  "drips": {
-    "filecoin": {
-      "ownedBy": "0xFb90943018928cBF18e6355629A250928Ca6Be02"
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git clone git@github.com:probe-lab/hermes.git
 Start Hermes by running
 
 ```shell
-go run ./cmd/hermes # requires Go >=1.24
+go run ./cmd/hermes # requires Go >=1.23
 ```
 
 <details>

--- a/eth/config_test.go
+++ b/eth/config_test.go
@@ -1,0 +1,208 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubnetConfigLoading validates that subnet configurations can be
+// properly loaded and validated from configuration data.
+func TestSubnetConfigLoading(t *testing.T) {
+	tests := []struct {
+		name          string
+		configData    map[string]*SubnetConfig
+		expectedValid bool
+		errorContains string
+	}{
+		{
+			name: "valid static config",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			name: "valid random config",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:  SubnetRandom,
+					Count: 10,
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			name: "valid range config",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:  SubnetStaticRange,
+					Start: 5,
+					End:   10,
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			name: "valid all config",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type: SubnetAll,
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			name: "invalid topic",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipBlockMessage: { // Doesn't support subnets
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+			},
+			expectedValid: false,
+			errorContains: "does not support subnets",
+		},
+		{
+			name: "invalid static config - no subnets",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{},
+				},
+			},
+			expectedValid: false,
+			errorContains: "requires at least one subnet",
+		},
+		{
+			name: "invalid random config - zero count",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:  SubnetRandom,
+					Count: 0,
+				},
+			},
+			expectedValid: false,
+			errorContains: "requires a positive count",
+		},
+		{
+			name: "invalid range config - start >= end",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:  SubnetStaticRange,
+					Start: 10,
+					End:   5,
+				},
+			},
+			expectedValid: false,
+			errorContains: "start must be less than end",
+		},
+		{
+			name: "mixed valid configs",
+			configData: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+				p2p.GossipSyncCommitteeMessage: {
+					Type:  SubnetRandom,
+					Count: 2,
+				},
+				p2p.GossipBlobSidecarMessage: {
+					Type:  SubnetStaticRange,
+					Start: 0,
+					End:   3,
+				},
+			},
+			expectedValid: true,
+		},
+	}
+
+	// Setup node config for validation
+	config := setupTestNodeConfig()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the subnet configs
+			config.SubnetConfigs = tt.configData
+
+			// Validate
+			err := config.Validate()
+
+			if tt.expectedValid {
+				assert.NoError(t, err, "Expected config to be valid")
+			} else {
+				assert.Error(t, err, "Expected config to be invalid")
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			}
+		})
+	}
+}
+
+// Test that the node configuration can handle getting topics with both configured
+// and unconfigured subnets
+func TestTopicGenerationWithMixedConfig(t *testing.T) {
+	// Setup
+	config := setupTestNodeConfig()
+	encoder := &encoder.SszNetworkEncoder{}
+
+	// Test with a mix of configured and unconfigured topics
+	config.SubnetConfigs = map[string]*SubnetConfig{
+		// Configure attestations but leave sync committee and blob sidecar with defaults
+		p2p.GossipAttestationMessage: {
+			Type:    SubnetStatic,
+			Subnets: []uint64{1, 2, 3},
+		},
+	}
+
+	// Get topics
+	topics := config.getDesiredFullTopics(*encoder)
+
+	// Validate attestation topics match configuration
+	attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+	require.NoError(t, err)
+
+	// Should have exactly the configured attestation subnets
+	hasAttSubnet := make(map[uint64]bool)
+	for _, topic := range topics {
+		for subnet := uint64(0); subnet < globalBeaconConfig.AttestationSubnetCount; subnet++ {
+			expectedTopic := formatSubnetTopic(attTopicFormat, subnet, *encoder)
+			if topic == expectedTopic {
+				hasAttSubnet[subnet] = true
+			}
+		}
+	}
+
+	// Should have exactly subnets 1, 2, 3
+	assert.True(t, hasAttSubnet[1], "Missing configured attestation subnet 1")
+	assert.True(t, hasAttSubnet[2], "Missing configured attestation subnet 2")
+	assert.True(t, hasAttSubnet[3], "Missing configured attestation subnet 3")
+	assert.False(t, hasAttSubnet[0], "Should not have attestation subnet 0")
+	assert.False(t, hasAttSubnet[4], "Should not have attestation subnet 4")
+
+	// Validate sync committee topics - should have all subnets (default behavior)
+	syncTopicFormat, err := topicFormatFromBase(p2p.GossipSyncCommitteeMessage)
+	require.NoError(t, err)
+
+	syncSubnetCount := 0
+	for _, topic := range topics {
+		for subnet := uint64(0); subnet < globalBeaconConfig.SyncCommitteeSubnetCount; subnet++ {
+			expectedTopic := formatSubnetTopic(syncTopicFormat, subnet, *encoder)
+			if topic == expectedTopic {
+				syncSubnetCount++
+			}
+		}
+	}
+
+	// Should have all sync committee subnets
+	assert.Equal(t, int(globalBeaconConfig.SyncCommitteeSubnetCount), syncSubnetCount,
+		"Should have all sync committee subnets by default")
+}

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -2,7 +2,7 @@ package eth
 
 import (
 	"crypto/ecdsa"
-	cryptorand "crypto/rand"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -229,7 +229,7 @@ func (n *NodeConfig) PrivateKey() (*crypto.Secp256k1PrivateKey, error) {
 	var privBytes []byte
 	if n.PrivateKeyStr == "" {
 		slog.Debug("Generating new private key")
-		key, err := ecdsa.GenerateKey(gcrypto.S256(), cryptorand.Reader)
+		key, err := ecdsa.GenerateKey(gcrypto.S256(), rand.Reader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate key: %w", err)
 		}
@@ -509,4 +509,3 @@ func (n *NodeConfig) getDefaultTopicScoreParams(encoder encoder.NetworkEncoding,
 	}
 	return topicScores
 }
-

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -482,7 +482,7 @@ func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []str
 		subnets, withSubnets := HasSubnets(topicBase)
 		if withSubnets {
 			// Get the config for this topic if it exists.
-			config, _ := n.SubnetConfigs[topicBase]
+			config := n.SubnetConfigs[topicBase]
 
 			// Get the subnet IDs to subscribe to.
 			subnetsToSubscribe := GetSubscribedSubnets(config, subnets)

--- a/eth/node_config_test.go
+++ b/eth/node_config_test.go
@@ -1,0 +1,178 @@
+package eth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
+)
+
+func setupTestNodeConfig() *NodeConfig {
+	globalBeaconConfig = defaultTestBeaconConfig()
+
+	return &NodeConfig{
+		GenesisConfig: &GenesisConfig{
+			GenesisTime:          time.Unix(123456789, 0),
+			GenesisValidatorRoot: []byte{1, 2, 3},
+		},
+		NetworkConfig:   &params.NetworkConfig{},
+		BeaconConfig:    globalBeaconConfig,
+		ForkDigest:      [4]byte{1, 2, 3, 4},
+		DialTimeout:     60 * time.Second,
+		Devp2pHost:      "127.0.0.1",
+		Libp2pHost:      "127.0.0.1",
+		PrysmHost:       "127.0.0.1",
+		MaxPeers:        50,
+		DialConcurrency: 10,
+		Tracer:          nooptrace.NewTracerProvider().Tracer("test"),
+		Meter:           noop.NewMeterProvider().Meter("test"),
+	}
+}
+
+func TestNodeConfig_ValidateSubnetConfigs(t *testing.T) {
+	tests := []struct {
+		name          string
+		subnetConfigs map[string]*SubnetConfig
+		expectErrMsg  string
+	}{
+		{
+			name: "valid subnet configs",
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+				p2p.GossipSyncCommitteeMessage: {
+					Type:  SubnetRandom,
+					Count: 2,
+				},
+			},
+			expectErrMsg: "",
+		},
+		{
+			name: "invalid topic",
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipBlockMessage: { // Block topic doesn't support subnets
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+			},
+			expectErrMsg: "does not support subnets",
+		},
+		{
+			name: "invalid subnet config",
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{100}, // Out of range
+				},
+			},
+			expectErrMsg: "out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setupTestNodeConfig()
+			cfg.SubnetConfigs = tt.subnetConfigs
+
+			err := cfg.Validate()
+
+			if tt.expectErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNodeConfig_GetDesiredFullTopics(t *testing.T) {
+	// Setup a test encoder
+	ssz := encoder.SszNetworkEncoder{}
+
+	tests := []struct {
+		name           string
+		subnetConfigs  map[string]*SubnetConfig
+		wantTopicsFunc func(t *testing.T, topics []string)
+	}{
+		{
+			name: "static subnet config",
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2, 3},
+				},
+			},
+			wantTopicsFunc: func(t *testing.T, topics []string) {
+				// Check that the expected subnet topics are present
+				attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+				require.NoError(t, err)
+
+				// Check that each of our configured subnets is included
+				for _, subnet := range []uint64{1, 2, 3} {
+					subnetTopic := formatSubnetTopic(attTopicFormat, subnet, ssz)
+					assert.Contains(t, topics, subnetTopic,
+						"Expected subnet topic not found in result")
+				}
+
+				// Verify subnet 0 is NOT included (not in our static list)
+				subnetZeroTopic := formatSubnetTopic(attTopicFormat, 0, ssz)
+				assert.NotContains(t, topics, subnetZeroTopic,
+					"Subnet topic that wasn't configured was included")
+			},
+		},
+		{
+			name: "all subnets config",
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type: SubnetAll,
+				},
+			},
+			wantTopicsFunc: func(t *testing.T, topics []string) {
+				// For all subnet config, we expect topics for all attestation subnets
+				attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+				require.NoError(t, err)
+
+				totalAttSubnets := int(globalBeaconConfig.AttestationSubnetCount)
+				attSubnetTopicCount := 0
+
+				// Count how many attestation subnet topics we have
+				for _, topic := range topics {
+					for subnet := uint64(0); subnet < globalBeaconConfig.AttestationSubnetCount; subnet++ {
+						if topic == formatSubnetTopic(attTopicFormat, subnet, ssz) {
+							attSubnetTopicCount++
+							break
+						}
+					}
+				}
+
+				assert.Equal(t, totalAttSubnets, attSubnetTopicCount,
+					"Expected topics for all attestation subnets")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setupTestNodeConfig()
+			cfg.SubnetConfigs = tt.subnetConfigs
+
+			topics := cfg.getDesiredFullTopics(ssz)
+			tt.wantTopicsFunc(t, topics)
+		})
+	}
+}
+
+// Helper function to format a subnet topic like NodeConfig does
+func formatSubnetTopic(base string, subnet uint64, encoder encoder.NetworkEncoding) string {
+	return fmt.Sprintf(base, [4]byte{1, 2, 3, 4}, subnet) + encoder.ProtocolSuffix()
+}

--- a/eth/subnets.go
+++ b/eth/subnets.go
@@ -1,0 +1,195 @@
+package eth
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"time"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+)
+
+// SubnetSelectionType defines how subnets are selected for any topic
+type SubnetSelectionType string
+
+const (
+	// SubnetAll subscribes to all possible subnets.
+	SubnetAll SubnetSelectionType = "all"
+	// SubnetStatic subscribes to specific subnets.
+	SubnetStatic SubnetSelectionType = "static"
+	// SubnetRandom subscribes to a random set of subnets.
+	SubnetRandom SubnetSelectionType = "random"
+	// SubnetStaticRange subscribes to a range of subnets.
+	SubnetStaticRange SubnetSelectionType = "static_range"
+)
+
+// SubnetConfig configures which subnets to subscribe to for a topic.
+type SubnetConfig struct {
+	// Type of subnet selection.
+	Type SubnetSelectionType
+	// Specific subnet IDs to use when Type is Static.
+	Subnets []uint64
+	// Count of random subnets to select when Type is Random.
+	Count uint64
+	// Range start (inclusive) when Type is StaticRange.
+	Start uint64
+	// Range end (exclusive) when Type is StaticRange.
+	End uint64
+}
+
+// HasSubnets determines if a gossip topic has subnets, and if so, how many.
+// It returns the number of subnets for the topic and a boolean indicating
+// whether the topic has subnets.
+func HasSubnets(topic string) (subnets uint64, hasSubnets bool) {
+	switch topic {
+	case p2p.GossipAttestationMessage:
+		return globalBeaconConfig.AttestationSubnetCount, true
+
+	case p2p.GossipSyncCommitteeMessage:
+		return globalBeaconConfig.SyncCommitteeSubnetCount, true
+
+	case p2p.GossipBlobSidecarMessage:
+		return globalBeaconConfig.BlobsidecarSubnetCount, true
+
+	default:
+		return uint64(0), false
+	}
+}
+
+// Validate validates the subnet configuration against a total subnet count.
+func (s *SubnetConfig) Validate(topic string, subnetCount uint64) error {
+	switch s.Type {
+	case SubnetStatic:
+		if len(s.Subnets) == 0 {
+			return fmt.Errorf("static subnet selection requires at least one subnet for topic %s", topic)
+		}
+		for _, subnet := range s.Subnets {
+			if subnet >= subnetCount {
+				return fmt.Errorf(
+					"subnet %d is out of range (max: %d) for topic %s",
+					subnet, subnetCount-1, topic,
+				)
+			}
+		}
+	case SubnetRandom:
+		if s.Count == 0 {
+			return fmt.Errorf("random subnet selection requires a positive count for topic %s", topic)
+		}
+
+		if s.Count > subnetCount {
+			return fmt.Errorf(
+				"random subnet count %d exceeds total subnet count %d for topic %s",
+				s.Count, subnetCount, topic,
+			)
+		}
+	case SubnetStaticRange:
+		if s.Start >= s.End {
+			return fmt.Errorf("static range start must be less than end for topic %s", topic)
+		}
+
+		if s.End > subnetCount {
+			return fmt.Errorf(
+				"static range end %d exceeds total subnet count %d for topic %s",
+				s.End, subnetCount, topic,
+			)
+		}
+	case SubnetAll:
+	default:
+		return fmt.Errorf("unknown subnet selection type: %s for topic %s", s.Type, topic)
+	}
+
+	return nil
+}
+
+// GetSubscribedSubnets returns the subnet IDs to subscribe to for a given topic.
+// It handles the selection logic based on the subnet configuration.
+//
+// The function implements the following selection strategies:
+// - SubnetStatic: Uses the exact subnet IDs provided in config.Subnets
+// - SubnetRandom: Selects a random set of subnets based on config.Count
+// - SubnetStaticRange: Selects all subnets in the range [config.Start, config.End)
+// - SubnetAll (or nil config): Selects all available subnets (0 to totalSubnets-1)
+//
+// This centralized function allows consistent subnet selection across the codebase.
+func GetSubscribedSubnets(config *SubnetConfig, totalSubnets uint64) []uint64 {
+	if config == nil {
+		// If no config, subscribe to all subnets by default.
+		return getAllSubnets(totalSubnets)
+	}
+
+	switch config.Type {
+	case SubnetStatic:
+		return config.Subnets
+	case SubnetRandom:
+		return getRandomSubnets(totalSubnets, config.Count)
+	case SubnetStaticRange:
+		return getSubnetRange(config.Start, config.End)
+	default: // SubnetAll or unrecognized type.
+		return getAllSubnets(totalSubnets)
+	}
+}
+
+// getRandomSubnets creates a slice of random subnet IDs.
+func getRandomSubnets(totalSubnets, count uint64) []uint64 {
+	if count >= totalSubnets {
+		// If we want all or more subnets than exist, return all.
+		subnets := make([]uint64, totalSubnets)
+		for i := uint64(0); i < totalSubnets; i++ {
+			subnets[i] = i
+		}
+		return subnets
+	}
+
+	// Use the provided seed for deterministic results
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+
+	// Create a map to track selected subnets.
+	selectedSubnets := make(map[uint64]struct{})
+
+	// Generate random subnets until we have enough.
+	for uint64(len(selectedSubnets)) < count {
+		// Generate a random subnet ID.
+		subnetID := uint64(r.Intn(int(totalSubnets)))
+		selectedSubnets[subnetID] = struct{}{}
+	}
+
+	// Convert the map to a slice.
+	result := make([]uint64, 0, count)
+	for subnet := range selectedSubnets {
+		result = append(result, subnet)
+	}
+
+	// In production code, we don't need deterministic ordering,
+	// but for testing it's important to have consistent results.
+	// Since the overhead is minimal, we'll always sort for simplicity.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
+
+	return result
+}
+
+// getAllSubnets returns all subnet IDs from 0 to totalSubnets-1.
+func getAllSubnets(totalSubnets uint64) []uint64 {
+	subnets := make([]uint64, totalSubnets)
+	for i := uint64(0); i < totalSubnets; i++ {
+		subnets[i] = i
+	}
+
+	return subnets
+}
+
+// getSubnetRange returns subnet IDs in the range [start, end).
+func getSubnetRange(start, end uint64) []uint64 {
+	var (
+		count   = end - start
+		subnets = make([]uint64, count)
+	)
+
+	for i := uint64(0); i < count; i++ {
+		subnets[i] = start + i
+	}
+
+	return subnets
+}

--- a/eth/subnets_integration_test.go
+++ b/eth/subnets_integration_test.go
@@ -1,0 +1,155 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubnetIntegration tests the integration between the subnet selection logic
+// and the node configuration that uses it.
+func TestSubnetIntegration(t *testing.T) {
+	// Set up a test node config
+	cfg := setupTestNodeConfig()
+
+	// Set up an encoder for topic formatting
+	ssz := encoder.SszNetworkEncoder{}
+
+	// Test with no subnet configs
+	t.Run("no subnet configs", func(t *testing.T) {
+		cfg.SubnetConfigs = nil
+		topics := cfg.getDesiredFullTopics(ssz)
+
+		// Verify that all topics for all subnets are included (default behavior)
+		// For attestation subnets
+		attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+		require.NoError(t, err)
+
+		// Count attestation subnet topics
+		attSubnetCount := 0
+		for _, topic := range topics {
+			for subnet := uint64(0); subnet < globalBeaconConfig.AttestationSubnetCount; subnet++ {
+				if topic == formatSubnetTopic(attTopicFormat, subnet, ssz) {
+					attSubnetCount++
+					break
+				}
+			}
+		}
+
+		// Should have all attestation subnets by default
+		assert.Equal(t, int(globalBeaconConfig.AttestationSubnetCount), attSubnetCount)
+	})
+
+	// Test with specific subnet configs
+	t.Run("with subnet configs", func(t *testing.T) {
+		// Configure specific subnet selections
+		cfg.SubnetConfigs = map[string]*SubnetConfig{
+			p2p.GossipAttestationMessage: {
+				Type:    SubnetStatic,
+				Subnets: []uint64{1, 2, 3},
+			},
+			p2p.GossipSyncCommitteeMessage: {
+				Type:  SubnetRandom,
+				Count: 2,
+			},
+			p2p.GossipBlobSidecarMessage: {
+				Type:  SubnetStaticRange,
+				Start: 1,
+				End:   3,
+			},
+		}
+
+		// Get the desired topics
+		topics := cfg.getDesiredFullTopics(ssz)
+
+		// Verify attestation subnet topics (should be exactly subnets 1, 2, 3)
+		attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+		require.NoError(t, err)
+
+		// Check that each of our configured subnets is included
+		for _, subnet := range []uint64{1, 2, 3} {
+			subnetTopic := formatSubnetTopic(attTopicFormat, subnet, ssz)
+			assert.Contains(t, topics, subnetTopic,
+				"Expected attestation subnet topic not found")
+		}
+
+		// Verify attestation subnet 0 is NOT included (not in our static list)
+		subnetZeroTopic := formatSubnetTopic(attTopicFormat, 0, ssz)
+		assert.NotContains(t, topics, subnetZeroTopic,
+			"Attestation subnet not in config was included")
+
+		// Verify sync committee subnet topics
+		syncTopicFormat, err := topicFormatFromBase(p2p.GossipSyncCommitteeMessage)
+		require.NoError(t, err)
+
+		// Count sync committee topics
+		syncSubnetCount := 0
+		for _, topic := range topics {
+			for subnet := uint64(0); subnet < globalBeaconConfig.SyncCommitteeSubnetCount; subnet++ {
+				if topic == formatSubnetTopic(syncTopicFormat, subnet, ssz) {
+					syncSubnetCount++
+					break
+				}
+			}
+		}
+
+		// Should have exactly 2 sync committee subnets
+		assert.Equal(t, 2, syncSubnetCount, "Expected exactly 2 sync committee subnet topics")
+
+		// Verify blob sidecar subnet topics (should be subnets 1, 2)
+		blobTopicFormat, err := topicFormatFromBase(p2p.GossipBlobSidecarMessage)
+		require.NoError(t, err)
+
+		// Check range subnets are included
+		for _, subnet := range []uint64{1, 2} {
+			subnetTopic := formatSubnetTopic(blobTopicFormat, subnet, ssz)
+			assert.Contains(t, topics, subnetTopic,
+				"Expected blob sidecar subnet topic not found")
+		}
+
+		// Verify blob subnet 0 is NOT included (not in our range)
+		blobSubnetZeroTopic := formatSubnetTopic(blobTopicFormat, 0, ssz)
+		assert.NotContains(t, topics, blobSubnetZeroTopic,
+			"Blob subnet not in config range was included")
+	})
+}
+
+// Test that the node config validation properly checks subnet configs
+func TestNodeConfigValidatesSubnets(t *testing.T) {
+	cfg := setupTestNodeConfig()
+
+	// Test with valid configs
+	cfg.SubnetConfigs = map[string]*SubnetConfig{
+		p2p.GossipAttestationMessage: {
+			Type:    SubnetStatic,
+			Subnets: []uint64{1, 2, 3},
+		},
+	}
+	err := cfg.Validate()
+	assert.NoError(t, err, "Valid subnet config should not cause validation error")
+
+	// Test with invalid topic
+	cfg.SubnetConfigs = map[string]*SubnetConfig{
+		"invalid_topic": {
+			Type:    SubnetStatic,
+			Subnets: []uint64{1, 2, 3},
+		},
+	}
+	err = cfg.Validate()
+	assert.Error(t, err, "Invalid topic should cause validation error")
+	assert.Contains(t, err.Error(), "does not support subnets")
+
+	// Test with invalid subnet index
+	cfg.SubnetConfigs = map[string]*SubnetConfig{
+		p2p.GossipAttestationMessage: {
+			Type:    SubnetStatic,
+			Subnets: []uint64{999}, // Out of range
+		},
+	}
+	err = cfg.Validate()
+	assert.Error(t, err, "Invalid subnet index should cause validation error")
+	assert.Contains(t, err.Error(), "out of range")
+}

--- a/eth/subnets_test.go
+++ b/eth/subnets_test.go
@@ -1,0 +1,398 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasSubnets(t *testing.T) {
+	// Setup global beacon config for tests.
+	globalBeaconConfig = defaultTestBeaconConfig()
+
+	tests := []struct {
+		name          string
+		topic         string
+		wantSubnets   uint64
+		wantHasSubnet bool
+	}{
+		{
+			name:          "attestation topic",
+			topic:         p2p.GossipAttestationMessage,
+			wantSubnets:   globalBeaconConfig.AttestationSubnetCount,
+			wantHasSubnet: true,
+		},
+		{
+			name:          "sync committee topic",
+			topic:         p2p.GossipSyncCommitteeMessage,
+			wantSubnets:   globalBeaconConfig.SyncCommitteeSubnetCount,
+			wantHasSubnet: true,
+		},
+		{
+			name:          "blob sidecar topic",
+			topic:         p2p.GossipBlobSidecarMessage,
+			wantSubnets:   globalBeaconConfig.BlobsidecarSubnetCount,
+			wantHasSubnet: true,
+		},
+		{
+			name:          "non-subnet topic",
+			topic:         p2p.GossipBlockMessage,
+			wantSubnets:   0,
+			wantHasSubnet: false,
+		},
+		{
+			name:          "unknown topic",
+			topic:         "unknown_topic",
+			wantSubnets:   0,
+			wantHasSubnet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnets, hasSubnets := HasSubnets(tt.topic)
+			assert.Equal(t, tt.wantSubnets, subnets)
+			assert.Equal(t, tt.wantHasSubnet, hasSubnets)
+		})
+	}
+}
+
+func TestSubnetConfig_Validate(t *testing.T) {
+	const totalSubnets = 64
+
+	tests := []struct {
+		name       string
+		config     *SubnetConfig
+		topic      string
+		wantErrMsg string
+	}{
+		{
+			name: "valid static config",
+			config: &SubnetConfig{
+				Type:    SubnetStatic,
+				Subnets: []uint64{1, 2, 3},
+			},
+			topic: "test_topic",
+		},
+		{
+			name: "static config with no subnets",
+			config: &SubnetConfig{
+				Type:    SubnetStatic,
+				Subnets: []uint64{},
+			},
+			topic:      "test_topic",
+			wantErrMsg: "static subnet selection requires at least one subnet",
+		},
+		{
+			name: "static config with out of range subnet",
+			config: &SubnetConfig{
+				Type:    SubnetStatic,
+				Subnets: []uint64{1, 2, 100},
+			},
+			topic:      "test_topic",
+			wantErrMsg: "subnet 100 is out of range",
+		},
+		{
+			name: "valid random config",
+			config: &SubnetConfig{
+				Type:  SubnetRandom,
+				Count: 10,
+			},
+			topic: "test_topic",
+		},
+		{
+			name: "random config with zero count",
+			config: &SubnetConfig{
+				Type:  SubnetRandom,
+				Count: 0,
+			},
+			topic:      "test_topic",
+			wantErrMsg: "random subnet selection requires a positive count",
+		},
+		{
+			name: "random config with count exceeding total subnets",
+			config: &SubnetConfig{
+				Type:  SubnetRandom,
+				Count: totalSubnets + 1,
+			},
+			topic:      "test_topic",
+			wantErrMsg: "random subnet count 65 exceeds total subnet count 64",
+		},
+		{
+			name: "valid static range config",
+			config: &SubnetConfig{
+				Type:  SubnetStaticRange,
+				Start: 10,
+				End:   20,
+			},
+			topic: "test_topic",
+		},
+		{
+			name: "static range with start >= end",
+			config: &SubnetConfig{
+				Type:  SubnetStaticRange,
+				Start: 20,
+				End:   10,
+			},
+			topic:      "test_topic",
+			wantErrMsg: "static range start must be less than end",
+		},
+		{
+			name: "static range with end > total subnets",
+			config: &SubnetConfig{
+				Type:  SubnetStaticRange,
+				Start: 10,
+				End:   totalSubnets + 10,
+			},
+			topic:      "test_topic",
+			wantErrMsg: "static range end 74 exceeds total subnet count 64",
+		},
+		{
+			name: "valid all subnets config",
+			config: &SubnetConfig{
+				Type: SubnetAll,
+			},
+			topic: "test_topic",
+		},
+		{
+			name: "unknown subnet selection type",
+			config: &SubnetConfig{
+				Type: "unknown",
+			},
+			topic:      "test_topic",
+			wantErrMsg: "unknown subnet selection type: unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate(tt.topic, totalSubnets)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSubscribedSubnets(t *testing.T) {
+	const totalSubnets = 64
+
+	tests := []struct {
+		name           string
+		config         *SubnetConfig
+		wantSubnetFunc func(t *testing.T, subnets []uint64)
+	}{
+		{
+			name: "static subnets",
+			config: &SubnetConfig{
+				Type:    SubnetStatic,
+				Subnets: []uint64{1, 5, 10},
+			},
+			wantSubnetFunc: func(t *testing.T, subnets []uint64) {
+				assert.ElementsMatch(t, []uint64{1, 5, 10}, subnets)
+			},
+		},
+		{
+			name: "random subnets",
+			config: &SubnetConfig{
+				Type:  SubnetRandom,
+				Count: 10,
+			},
+			wantSubnetFunc: func(t *testing.T, subnets []uint64) {
+				assert.Len(t, subnets, 10)
+				// Check all subnets are within range
+				for _, subnet := range subnets {
+					assert.Less(t, int(subnet), int(totalSubnets))
+				}
+
+				// Check for uniqueness
+				uniqueMap := make(map[uint64]struct{})
+				for _, subnet := range subnets {
+					uniqueMap[subnet] = struct{}{}
+				}
+				assert.Equal(t, 10, len(uniqueMap), "Should have 10 unique subnet IDs")
+			},
+		},
+		{
+			name: "static range subnets",
+			config: &SubnetConfig{
+				Type:  SubnetStaticRange,
+				Start: 5,
+				End:   10,
+			},
+			wantSubnetFunc: func(t *testing.T, subnets []uint64) {
+				assert.ElementsMatch(t, []uint64{5, 6, 7, 8, 9}, subnets)
+			},
+		},
+		{
+			name: "all subnets",
+			config: &SubnetConfig{
+				Type: SubnetAll,
+			},
+			wantSubnetFunc: func(t *testing.T, subnets []uint64) {
+				assert.Len(t, subnets, totalSubnets)
+				expected := make([]uint64, totalSubnets)
+				for i := uint64(0); i < totalSubnets; i++ {
+					expected[i] = i
+				}
+				assert.ElementsMatch(t, expected, subnets)
+			},
+		},
+		{
+			name:   "nil config defaults to all subnets",
+			config: nil,
+			wantSubnetFunc: func(t *testing.T, subnets []uint64) {
+				assert.Len(t, subnets, totalSubnets)
+				expected := make([]uint64, totalSubnets)
+				for i := uint64(0); i < totalSubnets; i++ {
+					expected[i] = i
+				}
+				assert.ElementsMatch(t, expected, subnets)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnets := GetSubscribedSubnets(tt.config, totalSubnets)
+			tt.wantSubnetFunc(t, subnets)
+		})
+	}
+}
+
+func TestGetRandomSubnets(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalSubnets uint64
+		count        uint64
+		wantLen      int
+	}{
+		{
+			name:         "request fewer than total",
+			totalSubnets: 64,
+			count:        10,
+			wantLen:      10,
+		},
+		{
+			name:         "request equal to total",
+			totalSubnets: 64,
+			count:        64,
+			wantLen:      64,
+		},
+		{
+			name:         "request more than total",
+			totalSubnets: 64,
+			count:        100,
+			wantLen:      64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use the standard random function
+			subnets := getRandomSubnets(tt.totalSubnets, tt.count)
+
+			// Check length
+			assert.Len(t, subnets, tt.wantLen)
+
+			// Check all subnets are within range
+			for _, subnet := range subnets {
+				assert.Less(t, int(subnet), int(tt.totalSubnets))
+			}
+
+			// Check for uniqueness
+			uniqueMap := make(map[uint64]struct{})
+			for _, subnet := range subnets {
+				uniqueMap[subnet] = struct{}{}
+			}
+			assert.Len(t, uniqueMap, tt.wantLen)
+		})
+	}
+}
+
+func TestGetAllSubnets(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalSubnets uint64
+	}{
+		{
+			name:         "typical case",
+			totalSubnets: 64,
+		},
+		{
+			name:         "small number",
+			totalSubnets: 4,
+		},
+		{
+			name:         "zero subnets",
+			totalSubnets: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnets := getAllSubnets(tt.totalSubnets)
+
+			assert.Len(t, subnets, int(tt.totalSubnets))
+
+			for i := uint64(0); i < tt.totalSubnets; i++ {
+				assert.Equal(t, i, subnets[i])
+			}
+		})
+	}
+}
+
+func TestGetSubnetRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		start     uint64
+		end       uint64
+		wantCount int
+	}{
+		{
+			name:      "typical range",
+			start:     5,
+			end:       10,
+			wantCount: 5,
+		},
+		{
+			name:      "zero width range",
+			start:     5,
+			end:       5,
+			wantCount: 0,
+		},
+		{
+			name:      "large range",
+			start:     0,
+			end:       64,
+			wantCount: 64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnets := getSubnetRange(tt.start, tt.end)
+
+			assert.Len(t, subnets, tt.wantCount)
+
+			for i := uint64(0); i < uint64(tt.wantCount); i++ {
+				assert.Equal(t, tt.start+i, subnets[i])
+			}
+		})
+	}
+}
+
+// Helper function to create a default test beacon config
+func defaultTestBeaconConfig() *params.BeaconChainConfig {
+	return &params.BeaconChainConfig{
+		AttestationSubnetCount:   64,
+		SyncCommitteeSubnetCount: 4,
+		BlobsidecarSubnetCount:   6,
+	}
+}

--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,0 @@
-{
-  "opRetro": {
-    "projectId": "0x7504e494cb8d227193182e083128912173c14eaeecec9b90fa453de28377b269"
-  }
-}


### PR DESCRIPTION
This commit introduces the ability to configure which subnets a node subscribes to for gossip topics. This allows for more granular control over network traffic and resource usage.

The following changes were made:

- Added a `SubnetConfig` struct to represent the configuration for a subnet.
- Added a `SubnetSelectionType` enum to represent the different types of subnet selection.
- Added a `SubnetConfigs` field to the `NodeConfig` struct to store the subnet configurations.
- Added a `Validate` method to the `SubnetConfig` struct to validate the configuration.
- Added a `GetSubscribedSubnets` function to return the subnet IDs to subscribe to for a given topic.
- Modified the `getDesiredFullTopics` method to use the subnet configurations to determine which subnets to subscribe to.
- Added unit tests for the new functionality.

This change allows operators to reduce the number of gossip topics a node subscribes to, which can reduce network traffic and resource usage. For example, a node that is only interested in a subset of attestations can configure itself to only subscribe to the subnets that are relevant to it.

**Note:** At ethPandaOps we don't actually use the CLI args, so more than happy to remove these if you think this is added bloat.

<details>
  <summary>Usage</summary>

### Random Subnet Selection
```bash
--subnet.attestation.type=random --subnet.attestation.count=10
--subnet.synccommittee.type=random --subnet.synccommittee.count=2
--subnet.blobsidecar.type=random --subnet.blobsidecar.count=3
```

### Static Subnet Selection (specific subnets)
```bash
--subnet.attestation.type=static --subnet.attestation.subnets=1,5,10,15,20
--subnet.synccommittee.type=static --subnet.synccommittee.subnets=0,1
--subnet.blobsidecar.type=static --subnet.blobsidecar.subnets=0,2,4
```

### Static Range Subnet Selection
```bash
--subnet.attestation.type=static_range --subnet.attestation.start=0 --subnet.attestation.end=32
--subnet.synccommittee.type=static_range --subnet.synccommittee.start=0 --subnet.synccommittee.end=2
--subnet.blobsidecar.type=static_range --subnet.blobsidecar.start=0 --subnet.blobsidecar.end=3
```

### All Subnets (default behavior)
```bash
--subnet.attestation.type=all
--subnet.synccommittee.type=all
--subnet.blobsidecar.type=all
```
</details>