### PR TITLE
feat(eth): Implement delegated validation using Prysm client

### DIFF
--- a/eth/node.go
+++ b/eth/node.go
@@ -786,7 +786,18 @@ func (n *Node) setupValidation(ctx context.Context) ([]pubsub.Option, error) {
 		}
 	} else {
 		// Create Prysm client for delegated mode
-		prysmClient := &delegated.PrysmClient{}
+		scheme := "http"
+		if n.cfg.PrysmUseTLS {
+			scheme = "https"
+		}
+		grpcEndpoint := fmt.Sprintf("%s:%d", n.cfg.PrysmHost, n.cfg.PrysmPortGRPC)
+		httpEndpoint := fmt.Sprintf("%s://%s:%d", scheme, n.cfg.PrysmHost, n.cfg.PrysmPortHTTP)
+
+		prysmClient, err := delegated.NewRealPrysmClient(httpEndpoint, grpcEndpoint, n.cfg.PrysmUseTLS)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Prysm client: %w", err)
+		}
+
 		routerConfig.DelegatedConfig = &delegated.DelegatedConfig{
 			PrysmClient: prysmClient,
 			Logger:      logger,

--- a/eth/validation/delegated/delegated_validator.go
+++ b/eth/validation/delegated/delegated_validator.go
@@ -7,20 +7,21 @@ import (
 	"time"
 
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/golang/snappy"
 	lru "github.com/hashicorp/golang-lru/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	
+
 	"github.com/probe-lab/hermes/eth/validation/common"
 )
 
 // DelegatedConfig holds configuration for DelegatedValidator
 type DelegatedConfig struct {
-	PrysmClient      *PrysmClient
-	Logger           *logrus.Logger
-	CacheSize        int
-	MetricsRegistry  prometheus.Registerer
+	PrysmClient     *PrysmClient
+	Logger          *logrus.Logger
+	CacheSize       int
+	MetricsRegistry prometheus.Registerer
 }
 
 // DelegatedValidator delegates validation to an external Prysm node
@@ -30,7 +31,7 @@ type DelegatedValidator struct {
 	prysmClient  *PrysmClient
 	seenMessages *lru.Cache[string, time.Time]
 	metrics      atomic.Value
-	
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	mu     sync.RWMutex
@@ -41,28 +42,28 @@ func NewDelegatedValidator(config *DelegatedConfig) (*DelegatedValidator, error)
 	if config.Logger == nil {
 		config.Logger = logrus.New()
 	}
-	
+
 	cacheSize := config.CacheSize
 	if cacheSize == 0 {
 		cacheSize = common.DefaultCacheSize
 	}
-	
+
 	seenCache, err := lru.New[string, time.Time](cacheSize)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	v := &DelegatedValidator{
 		config:       config,
 		logger:       config.Logger,
 		prysmClient:  config.PrysmClient,
 		seenMessages: seenCache,
 	}
-	
+
 	// Initialize base metrics
 	metrics := &common.BaseMetrics{}
 	v.metrics.Store(metrics)
-	
+
 	return v, nil
 }
 
@@ -70,14 +71,14 @@ func NewDelegatedValidator(config *DelegatedConfig) (*DelegatedValidator, error)
 func (v *DelegatedValidator) Start(ctx context.Context) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	
+
 	if v.ctx != nil {
 		return nil // Already started
 	}
-	
+
 	v.ctx, v.cancel = context.WithCancel(ctx)
 	v.logger.Info("Started delegated validator")
-	
+
 	return nil
 }
 
@@ -85,13 +86,13 @@ func (v *DelegatedValidator) Start(ctx context.Context) error {
 func (v *DelegatedValidator) Stop() error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	
+
 	if v.cancel != nil {
 		v.cancel()
 		v.ctx = nil
 		v.cancel = nil
 	}
-	
+
 	v.logger.Info("Stopped delegated validator")
 	return nil
 }
@@ -108,14 +109,14 @@ func (v *DelegatedValidator) GetMetrics() common.ValidatorMetrics {
 func (v *DelegatedValidator) ValidateMessage(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
 	start := time.Now()
 	messageType := common.ClassifyMessage(msg.GetTopic())
-	
+
 	// Record metrics
 	defer func() {
 		if m := v.GetMetrics(); m != nil {
 			m.RecordValidationDuration(messageType, time.Since(start).Seconds())
 		}
 	}()
-	
+
 	// Check message deduplication
 	msgID := string(msg.ID)
 	if _, seen := v.seenMessages.Get(msgID); seen {
@@ -123,7 +124,7 @@ func (v *DelegatedValidator) ValidateMessage(ctx context.Context, msg *pubsub.Me
 		return pubsub.ValidationIgnore
 	}
 	v.seenMessages.Add(msgID, time.Now())
-	
+
 	// Validate based on message type
 	var result pubsub.ValidationResult
 	switch messageType {
@@ -151,7 +152,7 @@ func (v *DelegatedValidator) ValidateMessage(ctx context.Context, msg *pubsub.Me
 		v.logger.WithField("topic", msg.Topic).Warn("Unknown message type")
 		result = pubsub.ValidationIgnore
 	}
-	
+
 	// Record validation result
 	resultStr := "accept"
 	switch result {
@@ -161,148 +162,256 @@ func (v *DelegatedValidator) ValidateMessage(ctx context.Context, msg *pubsub.Me
 		resultStr = "ignore"
 	}
 	v.recordResult(messageType, resultStr)
-	
+
 	return result
 }
 
 func (v *DelegatedValidator) validateBeaconBlock(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress beacon block")
+		return pubsub.ValidationReject
+	}
+
 	block := &ethpb.SignedBeaconBlock{}
-	if err := block.UnmarshalSSZ(msg.Data); err != nil {
+	if err := block.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal beacon block")
 		return pubsub.ValidationReject
 	}
-	
+
 	// TODO: Implement proper Prysm client calls
 	// For now, accept all valid blocks
 	_ = block
-	
+
 	return pubsub.ValidationAccept
 }
 
 func (v *DelegatedValidator) validateAggregateAndProof(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
-	aggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{}
-	if err := aggregateAndProof.UnmarshalSSZ(msg.Data); err != nil {
-		v.logger.WithError(err).Debug("Failed to unmarshal aggregate and proof")
+	// Check if Prysm client is available
+	if v.prysmClient == nil || v.prysmClient.client == nil {
+		v.logger.Debug("Prysm client not available, accepting message")
+		return pubsub.ValidationAccept
+	}
+
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress aggregate and proof")
 		return pubsub.ValidationReject
 	}
-	
+
+	// Try Electra version first (newer format)
+	aggregateAndProofElectra := &ethpb.SignedAggregateAttestationAndProofElectra{}
+	if err := aggregateAndProofElectra.UnmarshalSSZ(decompressed); err == nil {
+		// Submit Electra aggregate and proof
+		resp, err := v.prysmClient.client.SubmitSignedAggregateSelectionProofElectra(ctx, &ethpb.SignedAggregateSubmitElectraRequest{
+			SignedAggregateAndProof: aggregateAndProofElectra,
+		})
+		if err != nil {
+			v.logger.WithError(err).Debug("Prysm rejected Electra aggregate and proof")
+
+			return pubsub.ValidationReject
+		}
+
+		if resp != nil {
+			return pubsub.ValidationAccept
+		}
+
+		return pubsub.ValidationIgnore
+	}
+
+	// Fall back to pre-Electra version
+	aggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{}
+	if err := aggregateAndProof.UnmarshalSSZ(decompressed); err != nil {
+		v.logger.WithError(err).Debug("Failed to unmarshal aggregate and proof (both Electra and pre-Electra)")
+		return pubsub.ValidationReject
+	}
+
 	resp, err := v.prysmClient.client.SubmitSignedAggregateSelectionProof(ctx, &ethpb.SignedAggregateSubmitRequest{
 		SignedAggregateAndProof: aggregateAndProof,
 	})
-	
+
 	if err != nil {
 		v.logger.WithError(err).Debug("Prysm rejected aggregate and proof")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Check response
 	if resp != nil {
 		return pubsub.ValidationAccept
 	}
-	
+
 	return pubsub.ValidationIgnore
 }
 
 func (v *DelegatedValidator) validateVoluntaryExit(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Check if Prysm client is available
+	if v.prysmClient == nil || v.prysmClient.client == nil {
+		v.logger.Debug("Prysm client not available, accepting message")
+		return pubsub.ValidationAccept
+	}
+
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress voluntary exit")
+		return pubsub.ValidationReject
+	}
+
 	exit := &ethpb.SignedVoluntaryExit{}
-	if err := exit.UnmarshalSSZ(msg.Data); err != nil {
+	if err := exit.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal voluntary exit")
 		return pubsub.ValidationReject
 	}
-	
+
 	resp, err := v.prysmClient.client.ProposeExit(ctx, exit)
 	if err != nil {
 		v.logger.WithError(err).Debug("Prysm rejected voluntary exit")
 		return pubsub.ValidationReject
 	}
-	
+
 	if resp != nil {
 		return pubsub.ValidationAccept
 	}
-	
+
 	return pubsub.ValidationIgnore
 }
 
 func (v *DelegatedValidator) validateProposerSlashing(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress proposer slashing")
+		return pubsub.ValidationReject
+	}
+
 	slashing := &ethpb.ProposerSlashing{}
-	if err := slashing.UnmarshalSSZ(msg.Data); err != nil {
+	if err := slashing.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal proposer slashing")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Prysm doesn't have a direct proposer slashing submission method
 	// Accept if it parses correctly
 	return pubsub.ValidationAccept
 }
 
 func (v *DelegatedValidator) validateAttesterSlashing(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress attester slashing")
+		return pubsub.ValidationReject
+	}
+
 	slashing := &ethpb.AttesterSlashing{}
-	if err := slashing.UnmarshalSSZ(msg.Data); err != nil {
+	if err := slashing.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal attester slashing")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Prysm doesn't have a direct attester slashing submission method
 	// Accept if it parses correctly
 	return pubsub.ValidationAccept
 }
 
 func (v *DelegatedValidator) validateAttestation(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Check if Prysm client is available
+	if v.prysmClient == nil || v.prysmClient.client == nil {
+		v.logger.Debug("Prysm client not available, accepting message")
+		return pubsub.ValidationAccept
+	}
+
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress attestation")
+		return pubsub.ValidationReject
+	}
+
 	att := &ethpb.Attestation{}
-	if err := att.UnmarshalSSZ(msg.Data); err != nil {
+	if err := att.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal attestation")
 		return pubsub.ValidationReject
 	}
-	
+
 	resp, err := v.prysmClient.client.ProposeAttestation(ctx, att)
 	if err != nil {
 		v.logger.WithError(err).Debug("Prysm rejected attestation")
 		return pubsub.ValidationReject
 	}
-	
+
 	if resp != nil && resp.AttestationDataRoot != nil {
 		return pubsub.ValidationAccept
 	}
-	
+
 	return pubsub.ValidationIgnore
 }
 
 func (v *DelegatedValidator) validateSyncContribution(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress sync contribution")
+		return pubsub.ValidationReject
+	}
+
 	contribution := &ethpb.SignedContributionAndProof{}
-	if err := contribution.UnmarshalSSZ(msg.Data); err != nil {
+	if err := contribution.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal sync contribution")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Prysm doesn't have a direct sync contribution submission endpoint
 	// We'll accept it if it parses correctly
 	return pubsub.ValidationAccept
 }
 
 func (v *DelegatedValidator) validateSyncCommittee(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Check if Prysm client is available
+	if v.prysmClient == nil || v.prysmClient.client == nil {
+		v.logger.Debug("Prysm client not available, accepting message")
+		return pubsub.ValidationAccept
+	}
+
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress sync committee message")
+		return pubsub.ValidationReject
+	}
+
 	syncMsg := &ethpb.SyncCommitteeMessage{}
-	if err := syncMsg.UnmarshalSSZ(msg.Data); err != nil {
+	if err := syncMsg.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal sync committee message")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Submit sync committee message
-	_, err := v.prysmClient.client.SubmitSyncMessage(ctx, syncMsg)
+	_, err = v.prysmClient.client.SubmitSyncMessage(ctx, syncMsg)
 	if err != nil {
 		v.logger.WithError(err).Debug("Prysm rejected sync committee message")
 		return pubsub.ValidationReject
 	}
-	
+
 	return pubsub.ValidationAccept
 }
 
 func (v *DelegatedValidator) validateBlsToExecutionChange(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress BLS to execution change")
+		return pubsub.ValidationReject
+	}
+
 	change := &ethpb.SignedBLSToExecutionChange{}
-	if err := change.UnmarshalSSZ(msg.Data); err != nil {
+	if err := change.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal BLS to execution change")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Prysm v6 should have this endpoint
 	// For now, accept if it parses correctly
 	return pubsub.ValidationAccept
@@ -315,19 +424,26 @@ func (v *DelegatedValidator) validateBlobSidecar(ctx context.Context, msg *pubsu
 		v.logger.WithError(err).Debug("Failed to extract blob subnet")
 		return pubsub.ValidationReject
 	}
-	
+
+	// Decompress the snappy-compressed data
+	decompressed, err := snappy.Decode(nil, msg.Data)
+	if err != nil {
+		v.logger.WithError(err).Debug("Failed to decompress blob sidecar")
+		return pubsub.ValidationReject
+	}
+
 	sidecar := &ethpb.BlobSidecar{}
-	if err := sidecar.UnmarshalSSZ(msg.Data); err != nil {
+	if err := sidecar.UnmarshalSSZ(decompressed); err != nil {
 		v.logger.WithError(err).Debug("Failed to unmarshal blob sidecar")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Verify blob index matches subnet
 	if uint64(sidecar.Index) != subnet {
 		v.logger.Debug("Blob index doesn't match subnet")
 		return pubsub.ValidationReject
 	}
-	
+
 	// Accept if parsing succeeds and index matches
 	// Full KZG validation would be done by Prysm if it had the endpoint
 	return pubsub.ValidationAccept

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/dennis-tra/go-kinesis v0.0.0-20240326083914-7acf5f8dc24e
 	github.com/ethereum/go-ethereum v1.15.9
 	github.com/ferranbt/fastssz v0.1.4
+	github.com/golang/snappy v1.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/herumi/bls-eth-go-binary v1.36.1
@@ -104,7 +105,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,6 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e h1:4bw4WeyTYPp0smaXiJZCNnLrvVBqirQVreixayXezGc=
-github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
- Resolves issue where events weren't being validated in `delegated` mode (See logs below).
- Ensures `delegated` mode has the prysm client initialised correctly (Wasn't an issue previously as nothing validated - never made it to using the prysm client).

Before:

```bash
INFO[0000] Starting validation router                    mode=delegated
INFO[0000] Started delegated validator
DEBU[0005] Validating message                            counter=1 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0005] Failed to unmarshal aggregate and proof       error="incorrect offset"
DEBU[0005] Validation complete                           duration=5.6708e-05 result=1 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0005] Validating message                            counter=2 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0005] Failed to unmarshal aggregate and proof       error="incorrect offset"
DEBU[0005] Validation complete                           duration=4.3125e-05 result=1 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0005] Validating message                            counter=3 peer= topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy type=7
DEBU[0005] Failed to unmarshal sync contribution         error="incorrect size"
DEBU[0005] Validation complete                           duration=4.8125e-05 result=1 topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy
DEBU[0005] Validating message                            counter=4 peer= topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy type=7
DEBU[0005] Failed to unmarshal sync contribution         error="incorrect size"
DEBU[0006] Validating message                            counter=13 peer= topic=/eth2/5d6e7910/sync_committee_1/ssz_snappy type=6
DEBU[0006] Failed to unmarshal sync committee message    error="incorrect size"
DEBU[0006] Validation complete                           duration=0.000873916 result=1 topic=/eth2/5d6e7910/sync_committee_1/ssz_snappy
DEBU[0005] Validating message                            counter=4 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0005] Failed to unmarshal aggregate and proof       error="invalid ssz encoding. first variable element offset indexes into fixed value data"
DEBU[0005] Validation complete                           duration=3.75e-05 result=1 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
```

After:

```
INFO[0000] Starting validation router                    mode=delegated
INFO[0000] Started delegated validator
DEBU[0004] Validating message                            counter=1 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0004] Validation complete                           duration=0.003421542 result=0 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0004] Validating message                            counter=2 peer= topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy type=7
DEBU[0004] Validation complete                           duration=9.1916e-05 result=0 topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy
DEBU[0004] Validating message                            counter=3 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0004] Validating message                            counter=4 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0004] Validation complete                           duration=0.00111775 result=0 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0004] Validation complete                           duration=0.000642208 result=0 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0004] Validating message                            counter=5 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0004] Validating message                            counter=6 peer= topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy type=1
DEBU[0004] Validation complete                           duration=0.001052542 result=0 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0004] Validation complete                           duration=0.002157666 result=0 topic=/eth2/5d6e7910/beacon_aggregate_and_proof/ssz_snappy
DEBU[0004] Validating message                            counter=7 peer= topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy type=7
DEBU[0004] Validation complete                           duration=2.1083e-05 result=0 topic=/eth2/5d6e7910/sync_committee_contribution_and_proof/ssz_snappy

```
