### PR TITLE
feat(eth): Move event renderers to their own package

### DIFF
--- a/eth/events/output_full.go
+++ b/eth/events/output_full.go
@@ -1,9 +1,10 @@
-package eth
+package events
 
 import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/encoder"
 	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/probe-lab/hermes/host"
@@ -102,23 +103,23 @@ type TraceEventAttesterSlashing struct {
 
 // FullOutput is a renderer for full output.
 type FullOutput struct {
-	cfg *PubSubConfig
+	encoder encoder.NetworkEncoding
 }
 
 var _ host.DataStreamRenderer = (*FullOutput)(nil)
 
 // NewFullOutput creates a new instance of FullOutput.
-func NewFullOutput(cfg *PubSubConfig) host.DataStreamRenderer {
-	return &FullOutput{cfg: cfg}
+func NewFullOutput(enc encoder.NetworkEncoding) host.DataStreamRenderer {
+	return &FullOutput{encoder: enc}
 }
 
 // RenderPayload renders message into the destination.
 func (t *FullOutput) RenderPayload(evt *host.TraceEvent, msg *pubsub.Message, dst ssz.Unmarshaler) (*host.TraceEvent, error) {
-	if t.cfg.Encoder == nil {
+	if t.encoder == nil {
 		return nil, fmt.Errorf("no network encoding provided to raw output renderer")
 	}
 
-	if err := t.cfg.Encoder.DecodeGossip(msg.Data, dst); err != nil {
+	if err := t.encoder.DecodeGossip(msg.Data, dst); err != nil {
 		return nil, fmt.Errorf("decode gossip message: %w", err)
 	}
 

--- a/eth/events/output_full_test.go
+++ b/eth/events/output_full_test.go
@@ -1,4 +1,4 @@
-package eth
+package events
 
 import (
 	"encoding/hex"

--- a/eth/events/output_kinesis_test.go
+++ b/eth/events/output_kinesis_test.go
@@ -1,10 +1,11 @@
-package eth
+package events
 
 import (
 	"crypto/rand"
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/encoder"
 	v1 "github.com/OffchainLabs/prysm/v6/proto/engine/v1"
 	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -18,10 +19,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 	var (
 		topic    = "test-topic"
 		renderer = &KinesisOutput{
-			cfg: &PubSubConfig{
-				GenesisTime:    time.Unix(0, 0),
-				SecondsPerSlot: time.Duration(12) * time.Second,
-			},
+			encoder: &encoder.SszNetworkEncoder{},
 		}
 		baseMsg = &pubsub.Message{
 			Message: &pb.Message{
@@ -301,7 +299,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.SignedBeaconBlockAltair:
 				root, err := typedResult.GetBlock().HashTreeRoot()
 				if err != nil {
@@ -311,7 +309,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.SignedBeaconBlockBellatrix:
 				root, err := typedResult.GetBlock().HashTreeRoot()
 				if err != nil {
@@ -321,7 +319,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.SignedBeaconBlockCapella:
 				root, err := typedResult.GetBlock().HashTreeRoot()
 				if err != nil {
@@ -331,7 +329,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.SignedBeaconBlockDeneb:
 				root, err := typedResult.GetBlock().HashTreeRoot()
 				if err != nil {
@@ -341,7 +339,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.SignedBeaconBlockElectra:
 				root, err := typedResult.GetBlock().HashTreeRoot()
 				if err != nil {
@@ -351,7 +349,7 @@ func TestKinesisOutputRenderMethods(t *testing.T) {
 				require.Equal(t, typedResult.GetBlock().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetBlock().GetProposerIndex(), result["ValIdx"])
 				require.Equal(t, root, result["Root"])
-				require.Equal(t, renderer.cfg.GenesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.cfg.SecondsPerSlot), result["TimeInSlot"])
+				require.Equal(t, renderer.genesisTime.Add(time.Duration(typedResult.GetBlock().GetSlot())*renderer.secondsPerSlot), result["TimeInSlot"])
 			case *ethtypes.Attestation:
 				require.Equal(t, typedResult.GetData().GetSlot(), result["Slot"])
 				require.Equal(t, typedResult.GetData().GetCommitteeIndex(), result["CommIdx"])

--- a/eth/pubsub.go
+++ b/eth/pubsub.go
@@ -16,6 +16,7 @@ import (
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/thejerf/suture/v4"
 
+	"github.com/probe-lab/hermes/eth/events"
 	"github.com/probe-lab/hermes/host"
 	"github.com/probe-lab/hermes/tele"
 )
@@ -67,10 +68,10 @@ func NewPubSub(h *host.Host, cfg *PubSubConfig) (*PubSub, error) {
 
 	switch cfg.DataStream.OutputType() {
 	case host.DataStreamOutputTypeFull:
-		dsr = NewFullOutput(cfg)
+		dsr = events.NewFullOutput(cfg.Encoder)
 	// TODO: If wanted, add a new S3ParquetOutput
 	default:
-		dsr = NewKinesisOutput(cfg)
+		dsr = events.NewKinesisOutput(cfg.Encoder, cfg.GenesisTime, cfg.SecondsPerSlot)
 	}
 
 	return &PubSub{


### PR DESCRIPTION
Allows other consumers (e.g. our Prysm fork) to import the renders without causing a dep-cycle problem