### PR TITLE
refactor(eth): extract eth2 ENR key to a constant

### DIFF
--- a/eth/discovery.go
+++ b/eth/discovery.go
@@ -178,7 +178,7 @@ func (d *Discovery) Serve(ctx context.Context) (err error) {
 			continue
 		}
 		sszEncodedForkEntry := make([]byte, 16)
-		entry := enr.WithEntry(d.cfg.NetworkConfig.ETH2Key, &sszEncodedForkEntry)
+		entry := enr.WithEntry(eth2EnrKey, &sszEncodedForkEntry)
 		if err = node.Record().Load(entry); err != nil {
 			// failed reading eth2 enr entry, likely because it doesn't exist
 			continue

--- a/eth/discovery_config.go
+++ b/eth/discovery_config.go
@@ -14,6 +14,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	eth2EnrKey = "eth2" // The `eth2` ENR entry advertises the node's view of the fork schedule with an ssz-encoded ENRForkID value.
+)
+
 type DiscoveryConfig struct {
 	GenesisConfig *GenesisConfig
 	NetworkConfig *params.NetworkConfig
@@ -56,7 +60,7 @@ func (d *DiscoveryConfig) enrEth2Entry() (enr.Entry, error) {
 		return nil, fmt.Errorf("marshal enr fork id: %w", err)
 	}
 
-	return enr.WithEntry(d.NetworkConfig.ETH2Key, enc), nil
+	return enr.WithEntry(eth2EnrKey, enc), nil
 }
 
 func (d *DiscoveryConfig) enrAttnetsEntry() enr.Entry {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/probe-lab/hermes
 
 go 1.24.5
 
-replace github.com/OffchainLabs/prysm/v6 => github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250818194132-53df29b07f57
+replace github.com/OffchainLabs/prysm/v6 => github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250820235730-c5135f699535
 
 require (
 	github.com/OffchainLabs/prysm/v6 v6.0.4

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwS
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250818194132-53df29b07f57 h1:Gt4OaGMFDdq2roN0d5ebFoTxVBlODgdET0OnqIpEA/8=
-github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250818194132-53df29b07f57/go.mod h1:6UhEQHOVb5VCmJcTNNfAuByBtI/vnhDdXy2nvWXFzKU=
+github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250820235730-c5135f699535 h1:kloXWuI4dwnvuGwUzGITWzipwGITJgSuBcD9TIUgOqk=
+github.com/OffchainLabs/prysm/v6 v6.0.5-rc.1.0.20250820235730-c5135f699535/go.mod h1:6UhEQHOVb5VCmJcTNNfAuByBtI/vnhDdXy2nvWXFzKU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
- This bumps prysm/v6 to latest commit develop `c5135f699535` (more fulu support)
- The `NetworkConfig.ETH2Key` was removed upstream, infavour of local consts (see https://github.com/OffchainLabs/prysm/commit/c5135f699535c3a8d958e02f691a679fbd957a6a#diff-1593dcdb1649181d9ca59169d94f4a448280b38f202bc8e56d1f78166f377e0d)